### PR TITLE
chore: upgrade bazel_dep versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,17 +3,17 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "bazel_skylib", version = "1.8.2")
-bazel_dep(name = "rules_go", version = "0.58.3")
-bazel_dep(name = "rules_pkg", version = "1.1.0")
-bazel_dep(name = "gotopt2", version = "2.2.0")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "rules_go", version = "0.61.1")
+bazel_dep(name = "rules_pkg", version = "1.2.0")
+bazel_dep(name = "gotopt2", version = "2.8.3")
 bazel_dep(name = "rules_foreign_cc", version = "0.15.1")
-bazel_dep(name = "buildifier_prebuilt", version = "8.2.0.2")
-bazel_dep(name = "rules_shell", version = "0.6.1")
+bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.2")
+bazel_dep(name = "rules_shell", version = "0.8.0")
 
 bazel_dep(
     name = "bazel_skylib_gazelle_plugin",
-    version = "1.8.2",
+    version = "1.9.0",
     dev_dependency = True,
 )
 
@@ -32,13 +32,13 @@ http_archive(
     ],
 )
 
-bazel_dep(name = "gazelle", version = "0.46.0")
+bazel_dep(name = "gazelle", version = "0.51.3")
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")
 use_repo(go_deps, "com_github_davecgh_go_spew", "com_github_golang_glog", "com_github_mattn_go_sqlite3", "com_github_neovim_go_client", "dev_lsp_go_jsonrpc2", "dev_lsp_go_protocol")
 
-bazel_dep(name = "gcc_toolchain", version = "0.9.0")
+bazel_dep(name = "gcc_toolchain", version = "0.10.0")
 
 gcc_toolchains = use_extension("@gcc_toolchain//toolchain:module_extensions.bzl", "gcc_toolchains", dev_dependency = True)
 


### PR DESCRIPTION
This PR upgrades bazel_dep versions in MODULE.bazel to the latest available in the BCR.

* bazel_skylib: 1.8.2 -> 1.9.0
* rules_go: 0.58.3 -> 0.61.1
* rules_pkg: 1.1.0 -> 1.2.0
* gotopt2: 2.2.0 -> 2.8.3
* buildifier_prebuilt: 8.2.0.2 -> 8.5.1.2
* rules_shell: 0.6.1 -> 0.8.0
* bazel_skylib_gazelle_plugin: 1.8.2 -> 1.9.0
* gazelle: 0.46.0 -> 0.51.3
* gcc_toolchain: 0.9.0 -> 0.10.0