### PR TITLE
Fix tag-and-release workflow to skip when no changes

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -46,24 +46,30 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           release_branches: main
+          default_bump: false
       - name: Create a GitHub release
+        if: steps.tag_version.outputs.new_tag != ''
         uses: ncipollo/release-action@v1
         with:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           generateReleaseNotes: true
       - name: Get release tag
+        if: steps.tag_version.outputs.new_tag != ''
         id: get_version
         run: echo "VERSION=${{ steps.tag_version.outputs.new_tag }}" >> $GITHUB_ENV
       - name: Get repo name
+        if: steps.tag_version.outputs.new_tag != ''
         id: get_repo_name
         run: echo "REPO_NAME=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')" >> $GITHUB_ENV
       - name: "Publish source archive"
+        if: steps.tag_version.outputs.new_tag != ''
         uses: thedoctor0/zip-release@0.7.5
         with:
           type: 'zip'
           filename: "${{ env.REPO_NAME }}-${{ env.VERSION }}.zip"
           exclusions: '*.git* /*node_modules/* .editorconfig /bazel-*'
       - name: "Upload source archive"
+        if: steps.tag_version.outputs.new_tag != ''
         uses: ncipollo/release-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -74,6 +80,7 @@ jobs:
 
   release:
     needs: tag
+    if: needs.tag.outputs.tag_name != ''
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Fixes issue #32 where the tag and release workflow would create a new tag/release for the same commit every time it runs on a schedule if there are no new commits. Added `default_bump: false` to the tag action and conditional checks to subsequent steps.

---
*PR created automatically by Jules for task [9197799858307906906](https://jules.google.com/task/9197799858307906906) started by @filmil*